### PR TITLE
Add env-based API base URL for React UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,19 @@ atlas/
    # Then open http://localhost:8889 in browser
    ```
 
+4. **Run the React UI (optional):**
+   Build or start the React dashboard located in `data/react-ui`.
+   Set the `VITE_API_BASE_URL` environment variable so the UI can reach your
+   backend API:
+   ```bash
+   cd data/react-ui
+   # for development
+   VITE_API_BASE_URL=http://localhost:5000 npm run dev
+   # for a production build
+   VITE_API_BASE_URL=http://localhost:5000 npm run build
+   ```
+   You can also place this value in a `.env` file to avoid repeating it.
+
 ---
 
 ## 📈 Roadmap

--- a/data/react-ui/src/apiConfig.js
+++ b/data/react-ui/src/apiConfig.js
@@ -1,0 +1,1 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';

--- a/data/react-ui/src/components/HostsTable.jsx
+++ b/data/react-ui/src/components/HostsTable.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState, useRef } from "react";
 import { formatDistanceToNow, parseISO } from "date-fns";
+import { API_BASE_URL } from "../apiConfig";
 
 import {
   useReactTable,
@@ -15,7 +16,7 @@ export function HostsTable({ selectedNode }) {
   const [globalFilter, setGlobalFilter] = useState("");
 
   useEffect(() => {
-    fetch("https://atlas-api.vnerd.nl/hosts")
+    fetch(`${API_BASE_URL}/hosts`)
       .then((res) => res.json())
       .then(([normal, docker]) => {
         const flatten = (arr, group) =>

--- a/data/react-ui/src/components/NetworkMap.jsx
+++ b/data/react-ui/src/components/NetworkMap.jsx
@@ -3,6 +3,7 @@ import { Network } from "vis-network";
 import { DataSet } from "vis-data";
 import { SelectedNodePanel } from "./SelectedNodePanel";
 import { NetworkSettingsPanel } from "./NetworkSettingsPanel";
+import { API_BASE_URL } from "../apiConfig";
 
 
 function getSubnet(ip) {
@@ -35,7 +36,7 @@ export function NetworkMap() {
   useEffect(() => {
     async function fetchData() {
       try {
-        const res = await fetch("https://atlas-api.vnerd.nl/hosts");
+        const res = await fetch(`${API_BASE_URL}/hosts`);
         const json = await res.json();
         const [nonDockerHosts, dockerHosts] = json;
         setRawData({ nonDockerHosts, dockerHosts });

--- a/data/react-ui/src/components/ScriptsPanel.jsx
+++ b/data/react-ui/src/components/ScriptsPanel.jsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { API_BASE_URL } from "../apiConfig";
 
 const scripts = [
   { label: "Fast Host Scan", key: "scan-hosts-fast" },
@@ -18,7 +19,7 @@ export function ScriptsPanel() {
     setError("");
 
     try {
-      const res = await fetch(`https://atlas-api.vnerd.nl/scripts/run/${scriptKey}`, {
+      const res = await fetch(`${API_BASE_URL}/scripts/run/${scriptKey}`, {
         method: "POST",
       });
       const data = await res.json();

--- a/data/react-ui/src/hooks/useNetworkStats.js
+++ b/data/react-ui/src/hooks/useNetworkStats.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { API_BASE_URL } from "../apiConfig";
 
 function getSubnet(ip) {
   return ip.split(".").slice(0, 3).join(".");
@@ -16,7 +17,7 @@ export function useNetworkStats() {
   useEffect(() => {
     async function fetchStats() {
       try {
-        const res = await fetch("https://atlas-api.vnerd.nl/hosts");
+        const res = await fetch(`${API_BASE_URL}/hosts`);
         const json = await res.json();
         const [normalHosts, dockerHosts] = json;
 


### PR DESCRIPTION
## Summary
- pull API base URL from `import.meta.env` via a new `apiConfig` module
- update NetworkMap, HostsTable, ScriptsPanel, and hooks to use it
- document how to set `VITE_API_BASE_URL` when building or running the React app

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68485060bbec832482692a6c963a55da