### PR TITLE
Update docker script path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,16 +65,16 @@
 ```
 atlas/
 ├── config/
-│   └── logs/
-│       ├── docker.log        # Docker container info
-│       ├── nmap.log          # Nmap scan results
-│       └── docker_hosts.log  # Processed container data
+│   ├── logs/
+│   │   ├── docker.log        # Docker container info
+│   │   ├── nmap.log          # Nmap scan results
+│   │   └── docker_hosts.log  # Processed container data
+│   └── scripts/
+│       └── docker_script.sh  # Script to scan Docker containers
 ├── data/
 │   └── html/
 │       ├── visuals/          # G6-based working dashboard
 │       └── visuals2/         # vis.js-based dashboard version
-├── scripts/
-│   └── docker_script.sh      # Script to scan Docker containers
 └── README.md
 ```
 
@@ -90,7 +90,7 @@ atlas/
 
 2. **Run the scanner script inside your container:**
    ```bash
-   bash scripts/docker_script.sh
+   bash config/scripts/docker_script.sh
    ```
 
 3. **Serve the dashboard using Nginx or Python server:**


### PR DESCRIPTION
## Summary
- fix README to reference docker_script.sh under config/scripts
- update project structure example accordingly

## Testing
- `grep -n docker_script README.md`

------
https://chatgpt.com/codex/tasks/task_e_6848501d10208324823e4a9f41d9fcc0