### PR TITLE
Fix HostsTable scrolling behavior

### DIFF
--- a/data/react-ui/src/components/HostsTable.jsx
+++ b/data/react-ui/src/components/HostsTable.jsx
@@ -82,13 +82,12 @@ export function HostsTable({ selectedNode }) {
   });
 
   useEffect(() => {
-    if (!selectedNode || !tableContainerRef.current) return;
+    if (!selectedNode) return;
     const rowIndex = data.findIndex((row) => row.ip === selectedNode.ip);
     if (rowIndex >= 0) {
-      const offset = rowVirtualizer.getVirtualItems().find(v => v.index === rowIndex)?.start;
-      if (offset !== undefined) {
-        tableContainerRef.current.scrollTop = offset;
-      }
+      // useVirtualizer provides an API to scroll to a specific index
+      // which works even when the row isn't currently rendered
+      rowVirtualizer.scrollToIndex(rowIndex);
     }
   }, [selectedNode, data, rowVirtualizer]);
 


### PR DESCRIPTION
## Summary
- highlight a selected host row by scrolling directly to the index

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68484d0bada88324bb239a63864fe823