### PR TITLE
Potential fix for code scanning alert no. 6: Uncontrolled data used in path expression

### DIFF
--- a/config/scripts/app.py
+++ b/config/scripts/app.py
@@ -277,7 +277,12 @@ def stream_log(filename: str):
             safe_container = validate_container_name(container)
             cmd = ["docker", "logs", "-f", "--tail", "10", safe_container]
         else:
-            filepath = f"{LOGS_DIR}/{filename}"
+            base_dir = os.path.abspath(LOGS_DIR)
+            filepath = os.path.normpath(os.path.join(base_dir, filename))
+            # Ensure the resolved path stays within the logs directory
+            if os.path.commonpath([base_dir, filepath]) != base_dir:
+                yield "data: [ERROR] Invalid log file path\n\n"
+                return
             if not os.path.exists(filepath):
                 yield f"data: [ERROR] File not found: {filepath}\n\n"
                 return


### PR DESCRIPTION
Potential fix for [https://github.com/karam-ajaj/atlas/security/code-scanning/6](https://github.com/karam-ajaj/atlas/security/code-scanning/6)

In general, to fix uncontrolled path usage you must constrain user-supplied paths so they cannot escape an intended root directory. The usual pattern is: (1) resolve the user input against a known base directory, (2) normalize the result with `os.path.normpath` (or `os.path.realpath`), and (3) verify that the normalized result is still within the base directory and not a directory itself, before using it.

For this specific endpoint, the best fix without changing visible functionality is to normalize and validate any non-container `filename` before building the command. Instead of directly using `f"{LOGS_DIR}/{filename}"`, we should use `os.path.join(LOGS_DIR, filename)`, normalize it with `os.path.normpath`, and ensure that the resulting path is still under `LOGS_DIR` (e.g., by checking that `os.path.commonpath([LOGS_DIR, fullpath]) == os.path.abspath(LOGS_DIR)`). If the path is invalid (traverses outside the logs directory, is absolute, etc.), we should yield an error and return. This validation should be applied inside `stream_log`’s `event_generator` for the non-container case (lines 280–285). We already import `os` at the top, so no new imports are needed. All other behavior (streaming via `tail`, SSE format, etc.) can remain unchanged.

Concretely in `config/scripts/app.py`, within `stream_log`, replace the raw `filepath = f"{LOGS_DIR}/{filename}"` and subsequent existence check with a safe construction:

- Build `base_dir = os.path.abspath(LOGS_DIR)`.
- Build `filepath = os.path.normpath(os.path.join(base_dir, filename))`.
- Verify `os.path.commonpath([base_dir, filepath]) == base_dir`; if not, yield a descriptive error like `"Invalid log file path"` and return.
- Check `os.path.exists(filepath)` as before.
- Use this validated `filepath` in the `tail` command.

This confines file access to `LOGS_DIR` and resolves the CodeQL finding.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
